### PR TITLE
modify games table to better suit bgg api

### DIFF
--- a/src/db/schema/02_games.sql
+++ b/src/db/schema/02_games.sql
@@ -3,8 +3,16 @@ DROP TABLE IF EXISTS games CASCADE;
 CREATE TABLE games (
   id SERIAL PRIMARY KEY NOT NULL,
   name VARCHAR(255) NOT NULL,
-  publisher VARCHAR(255) NOT NULL,
+  DESCRIPTION TEXT,
+  year_published INTEGER,
+  age INTEGER,
+  play_time_min INTEGER,
+  play_time_max INTEGER,
+  -- publisher VARCHAR(255) NOT NULL,
   bgg_id INTEGER NOT NULL,
   average_bgg_rating INTEGER NOT NULL,
-  image VARCHAR(255) NOT NULL
+  thumbnail VARCHAR(255),
+  image VARCHAR(255),
+  category VARCHAR(255),
+  mechanic VARCHAR(255),
 );


### PR DESCRIPTION
Line 11 - Commented this one out because BGG API doesn't give publisher
Line 14 - Added thumbnail for smaller images when user are searching for games
Line 15 - Deleted NOT NULL constraint because some games does not have images from the BGG API
Line 16 / 17 - Added this two fields because there are many game mechanics and categories, it might be hard to put them in a separate table and reference them with id when creating seed file 

For example: 
I have noticed each game have at least 2-4 mechanics and categories, and there are at least 20 different mechanics and categories from what I observed. It might be a little hard to manage the seed file but we can discuss about this 